### PR TITLE
support api.DefaultsHandler

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -27,6 +27,26 @@ type Defaults struct {
 	httpDefaults
 }
 
+// Merge merges the supplies map of key/value combinations with the set of
+// handled defaults for the plugin. The supplied key/value map will NOT be
+// unpacked from its top-most plugin named element. So, for example, the
+// kube plugin should expect to get a map that looks like
+// "kube:namespace:<namespace>" and not "namespace:<namespace>".
+func (d *Defaults) Merge(vals map[string]any) {
+	kubeValsAny, ok := vals[pluginName]
+	if !ok {
+		return
+	}
+	kubeVals, ok := kubeValsAny.(map[string]string)
+	if !ok {
+		return
+	}
+	url, ok := kubeVals["base_url"]
+	if ok {
+		d.BaseURL = url
+	}
+}
+
 func (d *Defaults) UnmarshalYAML(node *yaml.Node) error {
 	if node.Kind != yaml.MappingNode {
 		return parse.ExpectedMapAt(node)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gdt-dev/http
 go 1.24.3
 
 require (
-	github.com/gdt-dev/core v1.10.0
+	github.com/gdt-dev/core v1.11.0
 	github.com/google/uuid v1.6.0
 	github.com/samber/lo v1.51.0
 	github.com/stretchr/testify v1.11.1
@@ -15,7 +15,6 @@ require (
 require (
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,10 +3,8 @@ github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QH
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/gdt-dev/core v1.10.0 h1:yX0MG2Tt+O34JGDFWcS63LV47lWpizto4HAyR/ugAC0=
-github.com/gdt-dev/core v1.10.0/go.mod h1:Bw8J6kUW0b7MUL8qW5e7qSbxb4SI9EAWQ0a4cAoPVpo=
-github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
-github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
+github.com/gdt-dev/core v1.11.0 h1:jEKDMZ8eoQIQMlTB2C6Ai6q7CfgHJ3y9MVFSzdgc208=
+github.com/gdt-dev/core v1.11.0/go.mod h1:Bw8J6kUW0b7MUL8qW5e7qSbxb4SI9EAWQ0a4cAoPVpo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=

--- a/plugin.go
+++ b/plugin.go
@@ -7,7 +7,6 @@ package http
 import (
 	"github.com/gdt-dev/core/api"
 	gdtplugin "github.com/gdt-dev/core/plugin"
-	"gopkg.in/yaml.v3"
 )
 
 var (
@@ -39,7 +38,7 @@ func (p *plugin) Info() api.PluginInfo {
 	}
 }
 
-func (p *plugin) Defaults() yaml.Unmarshaler {
+func (p *plugin) Defaults() api.DefaultsHandler {
 	return &Defaults{}
 }
 


### PR DESCRIPTION
Updates the http plugin to implement the new core `api.DefaultsHandler` interface and merge default values.

Issue gdt-dev/gdt#68